### PR TITLE
Update LinkShrink.net

### DIFF
--- a/services/linkshrink.net.js
+++ b/services/linkshrink.net.js
@@ -3,7 +3,6 @@
 	Hosts: p.pw
  */
 
-var vm = require('vm');
 var request = require('request');
 
 var Service = require('../service.js');
@@ -23,23 +22,13 @@ service.run = function(url, callback) {
 			return;
 		}
 		
-		var match = body.match(/\.href = ((\w+)\(.*?\))/);
+		var match = body.match(/\.href = revC\("(.*?)"\)/);
 		if (!match) {
 			callback('Cannot find the target URL');
 			return;
 		}
 		
-		var functionCall = match[1];
-		var functionName = match[2];
-		
-		match = body.match(new RegExp('<script>(function ' + functionName + '\\(.*?})</script>'));
-		if (!match) {
-			callback('Cannot find the decoding function');
-			return;
-		}
-		
-		var redirectUrl = vm.runInNewContext(match[1] + functionCall, {}, { timeout: 100 });
-		redirectUrl = redirectUrl.replace(/^http:/, 'https:');
+		var redirectUrl = 'https://linkshrink.net/' + new Buffer(match[1], 'base64').toString();
 		
 		//TODO : Retractor this
 		request({ url: redirectUrl, followRedirect: false }, function(error, response, body) {


### PR DESCRIPTION
Here is a new fix for LinkShrink.net.

Please, note that this involves the evaluation of untrusted code through a call to [`vm.runInNewContext`](https://nodejs.org/docs/latest-v0.12.x/api/vm.html#vm_vm_runinnewcontext_code_sandbox_options). However, this should be rather safe since the execution is sandboxed and limited to 100ms (a shorter limit might be fine too).