### PR TITLE
bc.cv regex fix

### DIFF
--- a/services/bc.vc.js
+++ b/services/bc.vc.js
@@ -19,7 +19,7 @@ service.run = function(url, callback) {
 			return;
 		}
 
-		var match = body.match(/{opt:'make_log',args:(.+?)}}/);
+		var match = body.match(/{\s*opt:\s*'make_log',\s*args:\s*{[:,\'\w\s]+}\s*}/);
 		if (!match) {
 			callback('The URL cannot be decrypted');
 			return;


### PR DESCRIPTION
I changed the regular expression.

Please review it.

For me it's working fine with the link:
`http://bc.vc/Eu0Oiv`