### PR TITLE
If the given link5s.com url link is not valid, it does not return error

### DIFF
--- a/services/link5s.com.js
+++ b/services/link5s.com.js
@@ -54,7 +54,11 @@ service.run = function(url, callback) {
 						$ = cheerio.load(body);
 						var link = $('a').attr('href');
 						
-						callback(null, link);
+						if (link === undefined) {
+							callback('The given URL is not found.');
+						} else {
+							callback(null, link);
+						}
 					}
 				});
 				


### PR DESCRIPTION
check it with:
```
'Link5s.com': {
	ok: 'http://link5s.com/Gmq',
	ko: 'http://link5s.com/Gmqsddfs',
}
```